### PR TITLE
chore(gulp-plugins): postTranspile task always runs after transpile task; add dev task [cfg-file-support]

### DIFF
--- a/packages/gulp-plugins/lib/boilerplate.js
+++ b/packages/gulp-plugins/lib/boilerplate.js
@@ -86,9 +86,6 @@ const boilerplate = function (gulp, opts) {
   if (opts.transpile && !opts.test) {
     defaultSequence.push('transpile');
   }
-  if (opts.postTranspile) {
-    defaultSequence.push(...opts.postTranspile);
-  }
   if (opts.test) {
     if (opts.watchE2E) {
       defaultSequence.push('test');
@@ -113,8 +110,8 @@ const boilerplate = function (gulp, opts) {
     spawnWatcher.configure('watch', opts.files, watchSequence);
   }
 
+  spawnWatcher.configure('dev', opts.files, ['transpile']);
   gulp.task('once', gulp.series(...defaultSequence));
-
   gulp.task('default', gulp.series(opts.watch ? 'watch' : 'once'));
 };
 

--- a/packages/gulp-plugins/lib/tasks/test.js
+++ b/packages/gulp-plugins/lib/tasks/test.js
@@ -10,10 +10,6 @@ const configure = function configure (gulp, opts, env) {
     ...env
   };
 
-  if (opts.postTranspile) {
-    testEnv.testDeps.push(...opts.postTranspile);
-  }
-
   let testTasks = [];
   if (opts.test) {
     unitTest.configure(gulp, opts, testEnv);

--- a/packages/gulp-plugins/lib/tasks/transpile.js
+++ b/packages/gulp-plugins/lib/tasks/transpile.js
@@ -11,18 +11,30 @@ const JSON_SOURCES = [
   'test/**/*.json',
 ];
 
+/**
+ * @param {import('gulp').Gulp} gulp - The gulp instance.
+ */
 const configure = function configure (gulp, opts, env) {
-  gulp.task('transpile', function () {
-    // json files can be copied as is, they don't need to be transpiled
-    const firstPath = gulp.src(JSON_SOURCES, {base: './'})
-      .pipe(gulp.dest(opts.transpileOut));
-    const secondPath = gulp.src(opts.files, {base: './'})
-      .pipe(gulpIf(isVerbose(), debug()))
-      .pipe(new Transpiler(opts).stream())
-      .on('error', env.spawnWatcher.handleError.bind(env.spawnWatcher))
-      .pipe(gulp.dest(opts.transpileOut));
-    return merge(firstPath, secondPath);
-  });
+  const tasks = [
+    function transpileSources () {
+      // json files can be copied as is, they don't need to be transpiled
+      const firstPath = gulp.src(JSON_SOURCES, {base: './'})
+        .pipe(gulp.dest(opts.transpileOut));
+      const secondPath = gulp.src(opts.files, {base: './'})
+        .pipe(gulpIf(isVerbose(), debug()))
+        .pipe(new Transpiler(opts).stream())
+        .on('error', env.spawnWatcher.handleError.bind(env.spawnWatcher))
+        .pipe(gulp.dest(opts.transpileOut));
+      return merge(firstPath, secondPath);
+    }
+  ];
+
+  if (opts.postTranspile && opts.postTranspile.length) {
+    gulp.task('post-transpile', gulp.parallel(opts.postTranspile));
+    tasks.push('post-transpile');
+  }
+
+  gulp.task('transpile', gulp.series(tasks));
 };
 
 module.exports = {


### PR DESCRIPTION
…ask; add dev task

- `postTranspile` would only run from certain _other_ tasks (like `test`).  This seemed incorrect, so now it runs after `transpile`, regardless of what task (or human) runs `transpile`.
- Added a `dev` task, which is like `watch`, except does not run tests (only transpiles)

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
